### PR TITLE
fix Already Invited message

### DIFF
--- a/lib/buttons/invite/index.js
+++ b/lib/buttons/invite/index.js
@@ -40,7 +40,7 @@ module.exports.handler = (data) => {
     }
 
     const email = data.actions[0].value
-    const domain = team.domain
+    const domain = team.team_name
     return invite(
       token,
       domain,
@@ -54,7 +54,7 @@ module.exports.handler = (data) => {
         return updateInviteButton(token, data, {
           title: 'Already Invited',
           color: '#FFFF00',
-          text: `:information_desk_person::skin-tone-5: This person has already been invited! <https://${domain}.slack.com/admin/invites|Manage invites>`
+          text: `:information_desk_person::skin-tone-5: This person has already been invited! I can't resend invites, but you can <https://${domain}.slack.com/admin/invites|do it manually>.`
         })
       } else if (!resp.ok && resp.error === 'user_disabled') {
         return updateInviteButton(token, data, {


### PR DESCRIPTION
There's no such thing as `team.domain`. I'm now honestly not sure how the hell invites *ever* worked. Is `https://undefined.slack.com/api` a valid endpoint that actually redirects according to the Slack team that the API key belongs to?! THAT'S BRILLIANT LOL