### PR TITLE
Support /list-private #channel

### DIFF
--- a/lib/models/group.js
+++ b/lib/models/group.js
@@ -20,7 +20,7 @@ module.exports.get = function (team, filter) {
       exclude_archived: 1
     }).then(res => (
       res.groups.filter(g => (
-        (g.name.match(filter) || g.purpose.value.match(filter)) &&
+        (g.name.match(filter) || `#${g.name}`.match(filter) || g.purpose.value.match(filter)) &&
         !g.name.match(/^admin/i) &&
         !g.purpose.value.match(/\[secret\]/gi)
       ))


### PR DESCRIPTION
When searching for a particular private channel (for example, if wanting to lookup the purpose of the channel without joining it), filtering by `#channel` returns no results. Technically, private channels don't have a leading `#`, but we frequently refer to them that way, so not-matching was unexpected.

Not sure this is the best way to implement: should we instead filter out a leading `#` in the `filter`?