### PR TITLE
Standardizes on user_id/user.id instead of using user_name/user.name

### DIFF
--- a/lib/buttons/join-private/index.js
+++ b/lib/buttons/join-private/index.js
@@ -23,7 +23,7 @@ module.exports.handler = (data) => {
       return chat.postMessageAsync({
         token,
         channel: channel.id,
-        text: `Invite request from <@${data.user.id}>! Use \`/invite @${data.user.name}\` to accept (anyone here can do this)!`
+        text: `Invite request from <@${data.user.id}>! Use \`/invite <@${data.user.id}>\` to accept (anyone here can do this)!`
       }).then(() => ({
         replace_original: true,
         text: `Invite request sent to #${channel.name}`

--- a/lib/commands/join-private.js
+++ b/lib/commands/join-private.js
@@ -28,7 +28,7 @@ function joinPrivate (argv) {
       return chat.postMessageAsync({
         token,
         channel: channel.id,
-        text: `Invite request from <@${argv.user_id}>! Use \`/invite @${argv.user_name}\` to accept (anyone here can do this)!`
+        text: `Invite request from <@${argv.user_id}>! Use \`/invite <@${argv.user_id}>\` to accept (anyone here can do this)!`
       }).then(() => ({
         text: `Join request sent. Please wait while the request is processed.\n\nRemember that private channels are not for allies unless otherwise specified and that there is a strong expectation of privacy in these channels -- what is said in there stays there.\n\nThe ${cocTxt} still fully applies in these spaces, with some channel-specific caveats (discussion of sexuality in lgbtq channels, for example).`
       }))


### PR DESCRIPTION
### Summary of changes

I replaced `@${user.name}`/`@${argv.user_name}` in the message sent from `/join-private` so that they used `<@${user.id}>`/`<@${argv.user_id}>` instead.

### Motivation

I noticed that Wheelie’s invite text sometimes says, lately, "Invite request from [someuser]! Use `/invite [somevariant]` to accept (anyone here can do this)!". After looking a little into it, [Slack’s page on slash commands](https://api.slack.com/slash-commands) says that

> [t]he user_name field is [being phased out](https://api.slack.com/changelog/2017-09-the-one-about-usernames). Always identify users by the combination of their `user_id` and `team_id`.

so I thought it would probably be easier to standardize on the linked `<@${user_id}>` instead of `@${user_name}`.

### Uncertainties/notes

I tested that links work inside of `monospaced markdown` from [Slack’s message builder](https://api.slack.com/docs/messages/builder?msg=%7B%22text%22%3A%22Here%27s%20a%20%60%3Chttp%3A%2F%2Fexample.com%7Clink%20inside%20some%20markdown%3E%60!%22%7D), but I’m not entirely sure that this will do what I want when it’s running. Fingers crossed, I guess?

Thanks for taking the time to read over this!