### PR TITLE
Remove unneccessary scope.

### DIFF
--- a/server.js
+++ b/server.js
@@ -15,8 +15,7 @@ const server = restify.createServer()
 const scopes = [
   'incoming-webhook',
   'commands',
-  'bot',
-  'chat:write:user'
+  'bot'
 ]
 
 server.use(restify.bodyParser())


### PR DESCRIPTION
Hey, I forked this for XOXO, and when I set it up, I noticed that it prompted me to give it access to send messages as my user. This seemed unnecessary both in terms of functionality and the code, so I removed it, and the app still works for us. It's worth noting that we don't use the invite user option at all (it's a closed Slack for people going to the festival), but it didn't look like that code needed this functionality either.