### PR TITLE
fix(group): use new conversation endpoint

### DIFF
--- a/lib/models/group.js
+++ b/lib/models/group.js
@@ -3,7 +3,7 @@
 const Team = require('../models/team')
 const slack = require('slack')
 const bluebird = require('bluebird')
-const groups = bluebird.promisifyAll(slack.groups)
+const conversations = bluebird.promisifyAll(slack.conversations)
 
 module.exports.get = function (team, filter) {
   filter = filter || /.*/
@@ -15,15 +15,24 @@ module.exports.get = function (team, filter) {
   }
   return teamP.then(team => {
     const token = team.bot.bot_access_token
-    return groups.listAsync({
+    return conversations.listAsync({
       token,
+      types: 'private_channel',
       exclude_archived: 1
-    }).then(res => (
-      res.groups.filter(g => (
+    }).then(res => {
+      const channels = res.channels.filter(g => (
         (g.name.match(filter) || `#${g.name}`.match(filter) || g.purpose.value.match(filter)) &&
         !g.name.match(/^admin/i) &&
         !g.purpose.value.match(/\[secret\]/gi)
-      ))
-    ))
+      )).map(channel =>
+        conversations.membersAsync({
+          token, channel: channel.id
+        }).then(res => {
+          channel.members = res.ok ? res.members : []
+          return channel
+        })
+      )
+      return bluebird.Promise.all(channels)
+    })
   })
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "querystring": "^0.2.0",
     "redis": "^2.6.3",
     "restify": "^4.2.0",
-    "slack": "^7.7.0",
+    "slack": "^8.4.2",
     "yargs": "^6.3.0"
   },
   "engines": {


### PR DESCRIPTION
The old groups endpoint were deprecated and stopped working on Feb 24.
Replace any instances of the old API with the new conversations API.
Unfortunately, the new API doesn't return a list of members for each channel,
so we need to make an extra call for each channel to fetch the list of
members (required to filter out channels the user are already in and to show
the number of members in each channel).

Ref: https://api.slack.com/changelog/2020-01-deprecating-antecedents-to-the-conversations-api